### PR TITLE
Fix: Hide bottom tab properly instead of setting display:none

### DIFF
--- a/src/CurvedBottomBar/components/navigator/index.tsx
+++ b/src/CurvedBottomBar/components/navigator/index.tsx
@@ -108,8 +108,11 @@ const BottomBarComponent = React.forwardRef<any, NavigatorBottomBarProps>(
     const MyTabBar = (props: any) => {
       const { state, navigation } = props;
       const focusedTab = state?.routes[state.index].name;
+      if (isShow) {
+        return null;
+      }
       return (
-        <View style={[styles.container, style, !isShow && styles.hide]}>
+        <View style={[styles.container, style]}>
           <SVG width={maxWidth} height={height + (type === 'DOWN' ? 0 : 30)}>
             <PATH
               fill={bgColor}

--- a/src/CurvedBottomBar/components/navigator/styles.ts
+++ b/src/CurvedBottomBar/components/navigator/styles.ts
@@ -37,7 +37,4 @@ export const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
   },
-  hide: {
-    display: 'none',
-  },
 });


### PR DESCRIPTION
Fix: If you hide the bottom tab with display none, then any Touchableopacity at the top of the screen is not working.